### PR TITLE
Null Logger

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -95,14 +95,22 @@ class PrintHandler(LoggingHandler):
 # pylint:disable=undefined-variable
 
 logger_cache = dict()
+null_logger = None
 
 
 def getLogger(name):
+    global null_logger
     """Create or retrieve a logger by name.
 
-    :param name: the name of the logger to create/retrieve
+    :param name: the name of the logger to create/retrieve None will cause the
+                 NullLogger instance to be returned.
 
     """
+    if not name or name == "":
+        if not null_logger:
+            null_logger = NullLogger()
+        return null_logger
+
     if name not in logger_cache:
         logger_cache[name] = Logger()
     return logger_cache[name]
@@ -112,11 +120,7 @@ class Logger:
     """Provide a logging api."""
 
     def __init__(self):
-        """Create an instance.
-
-        :param handler: what to use to output messages. Defaults to a PrintHandler.
-
-        """
+        """Create an instance."""
         self._level = NOTSET
         self._handler = PrintHandler()
 
@@ -201,3 +205,39 @@ class Logger:
 
         """
         self.log(CRITICAL, format_string, *args)
+
+
+class NullLogger:
+    """Provide an empty logger.
+    This can be used in place of a real logger to more efficiently disable logging."""
+
+    def __init__(self):
+        """Dummy implementation."""
+
+    def setLevel(self, value):
+        """Dummy implementation."""
+
+    def getEffectiveLevel(self):
+        """Dummy implementation."""
+        return NOTSET
+
+    def addHandler(self, hldr):
+        """Dummy implementation."""
+
+    def log(self, level, format_string, *args):
+        """Dummy implementation."""
+
+    def debug(self, format_string, *args):
+        """Dummy implementation."""
+
+    def info(self, format_string, *args):
+        """Dummy implementation."""
+
+    def warning(self, format_string, *args):
+        """Dummy implementation."""
+
+    def error(self, format_string, *args):
+        """Dummy implementation."""
+
+    def critical(self, format_string, *args):
+        """Dummy implementation."""

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -97,15 +97,15 @@ class PrintHandler(LoggingHandler):
 logger_cache = dict()
 null_logger = None
 
-
+# pylint:disable=global-statement
 def getLogger(name):
-    global null_logger
     """Create or retrieve a logger by name.
 
     :param name: the name of the logger to create/retrieve None will cause the
                  NullLogger instance to be returned.
 
     """
+    global null_logger
     if not name or name == "":
         if not null_logger:
             null_logger = NullLogger()
@@ -114,6 +114,9 @@ def getLogger(name):
     if name not in logger_cache:
         logger_cache[name] = Logger()
     return logger_cache[name]
+
+
+# pylint:enable=global-statement
 
 
 class Logger:

--- a/examples/logging_simpletest.py
+++ b/examples/logging_simpletest.py
@@ -6,8 +6,26 @@
 
 import adafruit_logging as logging
 
+# This should produce an error output
+
 logger = logging.getLogger("test")
 
 logger.setLevel(logging.ERROR)
 logger.info("Info message")
 logger.error("Error message")
+
+# This should produce no output
+
+null_logger = logging.getLogger(None)
+
+null_logger.setLevel(logging.ERROR)
+null_logger.info("Info message")
+null_logger.error("Error message")
+
+# This should produce no output
+
+null_logger = logging.getLogger("")
+
+null_logger.setLevel(logging.ERROR)
+null_logger.info("Info message")
+null_logger.error("Error message")

--- a/examples/logging_simpletest.py
+++ b/examples/logging_simpletest.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 # pylint:disable=undefined-variable,wildcard-import,no-name-in-module
-# pylint:disable=no-member
+# pylint:disable=no-member,invalid-name
+
+"""Briefly exercise the logger and null logger."""
 
 import adafruit_logging as logging
 


### PR DESCRIPTION
This implements the "Null Object" pattern. It allows logging to be completely and efficiently disabled without having to sprinkle "if logger" guards on every logger call (which can be error prone during maintenance).