### PR TITLE
Add format specifier for time value to keep alignment consistant

### DIFF
--- a/adafruit_logging/__init__.py
+++ b/adafruit_logging/__init__.py
@@ -111,7 +111,7 @@ class LoggingHandler:
         :param str message: the message to log
 
         """
-        return "{0}: {1} - {2}".format(time.monotonic(), level_for(log_level), message)
+        return "{0:<0.3f}: {1} - {2}".format(time.monotonic(), level_for(log_level), message)
 
     def emit(self, log_level: int, message: str):
         """Send a message where it should go.

--- a/adafruit_logging/__init__.py
+++ b/adafruit_logging/__init__.py
@@ -111,7 +111,9 @@ class LoggingHandler:
         :param str message: the message to log
 
         """
-        return "{0:<0.3f}: {1} - {2}".format(time.monotonic(), level_for(log_level), message)
+        return "{0:<0.3f}: {1} - {2}".format(
+            time.monotonic(), level_for(log_level), message
+        )
 
     def emit(self, log_level: int, message: str):
         """Send a message where it should go.


### PR DESCRIPTION
Added a simple format specifier for the time field of log messages. This should keep all time messages printing with 3 decimal places, padded where necessary.

This avoids situations like:
```
3753.39: INFO - ...
3753.39: INFO - ...
3753.4: INFO - ...
3753.4: INFO - ...
3753.4: INFO - ...
3753.41: INFO - ...
```
And instead ensures all the statements line up:
```
3665.209: INFO - ...
3665.237: INFO - ...
3665.360: INFO - ...
```
