### PR TITLE
Fix StreamHandler behavior

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -196,7 +196,7 @@ class StreamHandler(Handler):
 
         :param record: The record (message object) to be logged
         """
-        self.stream.write(self.format(record))
+        self.stream.write(self.format(record) + "\n")
 
 
 class FileHandler(StreamHandler):

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -248,7 +248,9 @@ logger_cache = {}
 def _addLogger(logger_name: str) -> None:
     """Adds the logger if it doesn't already exist"""
     if logger_name not in logger_cache:
-        logger_cache[logger_name] = Logger(logger_name)
+        new_logger = Logger(logger_name)
+        new_logger.addHandler(StreamHandler())
+        logger_cache[logger_name] = new_logger
 
 
 def getLogger(logger_name: str) -> "Logger":


### PR DESCRIPTION
Fixes #33 by:

- Adding `StreamHandler` as handler to new `Logger` instances using `getLogger()` by default
- Adds `\n` to `StreamHandler.emit()` so log lines are seperated onto newlines