### PR TITLE
Allow use of root logger

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -62,12 +62,8 @@ import sys
 from collections import namedtuple
 
 try:
-    from typing import Optional
-
-    try:
-        from typing import Protocol
-    except ImportError:
-        from typing_extensions import Protocol
+    from typing import Optional, Hashable
+    from typing_extensions import Protocol
 
     class WriteableStream(Protocol):
         """Any stream that can ``write`` strings"""

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -113,6 +113,8 @@ LEVELS = [
 for __value, __name in LEVELS:
     globals()[__name] = __value
 
+_ROOT_LOGGER_SENTINEL = object()
+
 
 def _level_for(value: int) -> str:
     """Convert a numeric level to the most appropriate name.
@@ -241,7 +243,7 @@ class NullHandler(Handler):
 logger_cache = {}
 
 
-def _addLogger(logger_name: str) -> None:
+def _addLogger(logger_name: Hashable) -> None:
     """Adds the logger if it doesn't already exist"""
     if logger_name not in logger_cache:
         new_logger = Logger(logger_name)
@@ -249,12 +251,14 @@ def _addLogger(logger_name: str) -> None:
         logger_cache[logger_name] = new_logger
 
 
-def getLogger(logger_name: str) -> "Logger":
+def getLogger(logger_name: Hashable = _ROOT_LOGGER_SENTINEL) -> "Logger":
     """Create or retrieve a logger by name; only retrieves loggers
     made using this function; if a Logger with this name does not
     exist it is created
 
-    :param str logger_name: The name of the `Logger` to create/retrieve.
+    :param Hashable logger_name: The name of the `Logger` to create/retrieve, this
+        is typically a ``str``.  If none is provided, the single root logger will
+        be created/retrieved.
     """
     _addLogger(logger_name)
     return logger_cache[logger_name]
@@ -263,12 +267,12 @@ def getLogger(logger_name: str) -> "Logger":
 class Logger:
     """The actual logger that will provide the logging API.
 
-    :param str name: The name of the logger, typically assigned by the
-        value from `getLogger`
+    :param Hashable name: The name of the logger, typically assigned by the
+        value from `getLogger`; this is typically a ``str``
     :param int level: (optional) The log level, default is ``NOTSET``
     """
 
-    def __init__(self, name: str, level: int = NOTSET) -> None:
+    def __init__(self, name: Hashable, level: int = NOTSET) -> None:
         """Create an instance."""
         self._level = level
         self.name = name

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -113,8 +113,6 @@ LEVELS = [
 for __value, __name in LEVELS:
     globals()[__name] = __value
 
-_ROOT_LOGGER_SENTINEL = object()
-
 
 def _level_for(value: int) -> str:
     """Convert a numeric level to the most appropriate name.
@@ -251,14 +249,15 @@ def _addLogger(logger_name: Hashable) -> None:
         logger_cache[logger_name] = new_logger
 
 
-def getLogger(logger_name: Hashable = _ROOT_LOGGER_SENTINEL) -> "Logger":
+def getLogger(logger_name: Hashable = "") -> "Logger":
     """Create or retrieve a logger by name; only retrieves loggers
     made using this function; if a Logger with this name does not
     exist it is created
 
     :param Hashable logger_name: The name of the `Logger` to create/retrieve, this
         is typically a ``str``.  If none is provided, the single root logger will
-        be created/retrieved.
+        be created/retrieved.  Note that unlike CPython, a blank string will also
+        access the root logger.
     """
     _addLogger(logger_name)
     return logger_cache[logger_name]


### PR DESCRIPTION
Resovles #38  by fixing `getLogger()` so that it can be used with no provided arguments to access a singular logger (which is considered the root logger now).

I haven't tested this, though, for what it's worth.

Additionally resolves #39 since it was a quick addition.