### PR TITLE
Make default logging level be consistent with CPython

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -45,8 +45,8 @@ Attributes
     INFO: int
         The INFO logging level for informative/informational messages.
     WARNING: int
-       The WARNING logging level, which is the default logging level, for warnings
-       that should be addressed/fixed.
+        The WARNING logging level, which is the default logging level, for warnings
+        that should be addressed/fixed.
     ERROR: int
         The ERROR logging level for Python exceptions that occur during runtime.
     CRITICAL: int

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -38,15 +38,15 @@ Attributes
         level (00 to 50). The str in each tuple is the string representation of
         that logging level ("NOTSET" to "CRITICAL"; see below).
     NOTSET: int
-        The NOTSET logging level, which is the default logging level that can be
-        used to indicate that a `Logger` should process any logging messages,
-        regardless of how severe those messages are.
+        The NOTSET logging level can be used to indicate that a `Logger` should
+        process any logging messages, regardless of how severe those messages are.
     DEBUG: int
         The DEBUG logging level, which is the lowest (least severe) real level.
     INFO: int
         The INFO logging level for informative/informational messages.
     WARNING: int
-       The WARNING logging level for warnings that should be addressed/fixed.
+       The WARNING logging level, which is the default logging level, for warnings
+       that should be addressed/fixed.
     ERROR: int
         The ERROR logging level for Python exceptions that occur during runtime.
     CRITICAL: int
@@ -268,10 +268,10 @@ class Logger:
 
     :param Hashable name: The name of the logger, typically assigned by the
         value from `getLogger`; this is typically a ``str``
-    :param int level: (optional) The log level, default is ``NOTSET``
+    :param int level: (optional) The log level, default is ``WARNING``
     """
 
-    def __init__(self, name: Hashable, level: int = NOTSET) -> None:
+    def __init__(self, name: Hashable, level: int = WARNING) -> None:
         """Create an instance."""
         self._level = level
         self.name = name


### PR DESCRIPTION
Hi,

This PR fixes: **Make default logging level be consistent with CPython: set to 30** #37 

Tested with Adafruit Feather RP2040.

```python
import adafruit_logging

l = adafruit_logging.getLogger()
print("default level: ", l.getEffectiveLevel())

l.debug("Debug message")
l.info("Info message")
l.warning("Warning message")
l.error("Error message")
l.critical("Critical message")
```

Output:

```
code.py output:
default level:  30
1534.524: WARNING - Warning message
1534.876: ERROR - Error message
1534.880: CRITICAL - Critical message
```

Please let me know if you have any comments!

Thanks!