### PR TITLE
allow multiple handlers per logger

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -140,6 +140,8 @@ be retrieved from it:
 - ``args`` - The additional positional arguments provided
 """
 
+raiseExceptions = False
+
 
 def _logRecordFactory(name, level, msg, args):
     return LogRecord(name, level, _level_for(level), msg, time.monotonic(), args)
@@ -338,7 +340,14 @@ class Logger:
         if record.levelno >= self._level:
             for handler in self._handlers:
                 if record.levelno >= handler.level:
-                    handler.emit(record)
+                    try:
+                        handler.emit(record)
+                    except Exception as e:  # pylint: disable=broad-except
+                        if raiseExceptions:
+                            raise e
+                        if sys.stderr:
+                            sys.stderr.write(f"Handler {handler} produced exception: "
+                                             f"{repr(e)}\n")
 
     def log(self, level: int, msg: str, *args) -> None:
         """Log a message.

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -156,9 +156,7 @@ class Handler:
         :param record: The record (message object) to be logged
         """
 
-        return "{0:<0.3f}: {1} - {2}".format(
-            record.created, record.levelname, record.msg
-        )
+        return f"{record.created:<0.3f}: {record.levelname} - {record.msg}"
 
     def emit(self, record: LogRecord) -> None:
         """Send a message where it should go.

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -140,10 +140,8 @@ be retrieved from it:
 - ``args`` - The additional positional arguments provided
 """
 
+# Whether to print exceptions caught during handler's emit().
 printHandlerExceptions = True
-"""
-Whether to print exceptions caught during handler's emit().
-"""
 
 
 def _logRecordFactory(name, level, msg, args):
@@ -347,8 +345,9 @@ class Logger:
                         handler.emit(record)
                     except Exception as e:  # pylint: disable=broad-except
                         if sys.stderr and printHandlerExceptions:
-                            sys.stderr.write(f"Handler {repr(handler)} produced exception: "
-                                             f"{str(e)}\n")
+                            sys.stderr.write(
+                                f"Handler {handler} produced exception: {e}\n"
+                            )
 
     def log(self, level: int, msg: str, *args) -> None:
         """Log a message.

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -140,9 +140,6 @@ be retrieved from it:
 - ``args`` - The additional positional arguments provided
 """
 
-# Whether to print exceptions caught during handler's emit().
-printHandlerExceptions = True
-
 
 def _logRecordFactory(name, level, msg, args):
     return LogRecord(name, level, _level_for(level), msg, time.monotonic(), args)
@@ -341,13 +338,7 @@ class Logger:
         if record.levelno >= self._level:
             for handler in self._handlers:
                 if record.levelno >= handler.level:
-                    try:
-                        handler.emit(record)
-                    except Exception as e:  # pylint: disable=broad-except
-                        if sys.stderr and printHandlerExceptions:
-                            sys.stderr.write(
-                                f"Handler {handler} produced exception: {e}\n"
-                            )
+                    handler.emit(record)
 
     def log(self, level: int, msg: str, *args) -> None:
         """Log a message.

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -146,7 +146,17 @@ def _logRecordFactory(name, level, msg, args):
 
 
 class Handler:
-    """Abstract logging message handler."""
+    """Base logging message handler."""
+
+    def __init__(self, level: int = NOTSET) -> None:
+        """Create Handler instance"""
+        self.level = level
+
+    def setLevel(self, level: int) -> None:
+        """
+        Set the logging level of this handler.
+        """
+        self.level = level
 
     # pylint: disable=no-self-use
     def format(self, record: LogRecord) -> str:
@@ -327,7 +337,8 @@ class Logger:
 
         if record.levelno >= self._level:
             for handler in self._handlers:
-                handler.emit(record)
+                if record.levelno >= handler.level:
+                    handler.emit(record)
 
     def log(self, level: int, msg: str, *args) -> None:
         """Log a message.

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -140,7 +140,10 @@ be retrieved from it:
 - ``args`` - The additional positional arguments provided
 """
 
-raiseExceptions = False
+printHandlerExceptions = True
+"""
+Whether to print exceptions caught during handler's emit().
+"""
 
 
 def _logRecordFactory(name, level, msg, args):
@@ -343,11 +346,9 @@ class Logger:
                     try:
                         handler.emit(record)
                     except Exception as e:  # pylint: disable=broad-except
-                        if raiseExceptions:
-                            raise e
-                        if sys.stderr:
-                            sys.stderr.write(f"Handler {handler} produced exception: "
-                                             f"{repr(e)}\n")
+                        if sys.stderr and printHandlerExceptions:
+                            sys.stderr.write(f"Handler {repr(handler)} produced exception: "
+                                             f"{str(e)}\n")
 
     def log(self, level: int, msg: str, *args) -> None:
         """Log a message.

--- a/examples/logging_simpletest.py
+++ b/examples/logging_simpletest.py
@@ -8,22 +8,31 @@
 
 import adafruit_logging as logging
 
-# This should produce an error output
+# This should produce an info output via default handler.
+
+logger_default_handler = logging.getLogger("default_handler")
+logger_default_handler.setLevel(logging.INFO)
+logger_default_handler.info("Default handler: Info message")
+assert not logger_default_handler.hasHandlers()
+
+# This should produce an error output via Stream Handler.
 
 logger = logging.getLogger("test")
-print_logger = logging.StreamHandler()
-logger.addHandler(print_logger)
+print_handler = logging.StreamHandler()
+logger.addHandler(print_handler)
+assert logger.hasHandlers()
 
 logger.setLevel(logging.ERROR)
-logger.info("Info message")
-logger.error("Error message")
+logger.info("Stream Handler: Info message")
+logger.error("Stream Handler: Error message")
 
-# This should produce no output
+# This should produce no output at all.
 
 null_logger = logging.getLogger("null")
 null_handler = logging.NullHandler()
 null_logger.addHandler(null_handler)
+assert null_logger.hasHandlers()
 
 null_logger.setLevel(logging.ERROR)
-null_logger.info("Info message")
-null_logger.error("Error message")
+null_logger.info("Null Handler: Info message")
+null_logger.error("Null Handler: Error message")


### PR DESCRIPTION
This change adds the possibility to have multiple handlers per logger. My motivation for this was a specific use case, that is a MQTT handler that I'd like to use in addition to the classic stream handler to make it easier to see what is going on with my QtPy's:
```python
from adafruit_logging import LogRecord, Handler
import adafruit_minimqtt.adafruit_minimqtt as MQTT
import ssl
import atexit


class MQTTHandler(Handler):
    def __init__(self, pool, broker: str, port: int, topic: str) -> None:
        """
        Setup MQTT broker connection for the specified topic.
        """
        super().__init__()

        self._mqtt_client = MQTT.MQTT(
            broker=broker,
            port=port,
            socket_pool=pool,
            ssl_context=ssl.create_default_context(),
        )

        self._topic = topic

        self._mqtt_client.connect()

        # To make it work in CPython.
        self.level = logging.WARNING

        # using weakref.finalize or defining __del__(self) might be wiser, depending on Python flavor.
        # In CPython, close() would be called from logging.shutdown()
        atexit.register(self.close)

    def close(self) -> None:
        self._mqtt_client.disconnect()

    def emit(self, record: LogRecord) -> None:
        """
        Publish message from the LogRecord to the MQTT broker.
        """
        self._mqtt_client.publish(self._topic, record.msg)
```
and the actual use:
```python
import adafruit_logging as logging
import socket
from mqtt_handler import MQTTHandler
import json


logger = logging.getLogger(__name__)
mqtt_topic = "devices/cupboard/qtpy"
mqttHandler = MQTTHandler(socket, "172.40.0.3", 1883, mqtt_topic)
logger.addHandler(mqttHandler)
data = {"foo": "bar"}
logger.warning(json.dumps(data))
```

While this seemed like a no brainer change initially, I had to do some choices that might not be in concordance with the intended use of this library. Namely:
  - a one-off warning is issued when there are no handlers in given logger and message is to be emitted
  - a warning message to stderr is printed if one of the handlers' `emit()` raises exception

Specifically the second choice is a bit stronger than what is found in CPython (see the comments on differences  I found between CPython and CircuitPython logging on [1]), however my feeling was that in embedded environment (where CircuitPython is more likely to be used, I think) it is more important to make sure all the handlers are visited during `emit()`, no matter what the individual outcome is. To see how it works in action, consider this handler:
```python
from adafruit_logging import LogRecord, Handler


class RogueHandler(Handler):
    def __init__(self) -> None:
        """Defer the initialization to the parent.
        """
        super().__init__()

    def emit(self, record: LogRecord) -> None:
        """Raise exception.
        """
        raise Exception("broken emit")
```
and its use:
```python
import adafruit_logging as logging
from rogue_handler import RogueHandler

logger = logging.getLogger(__name__)
rogueHandler = RogueHandler()
logger.addHandler(rogueHandler)
fileHandler = logging.FileHandler("log.txt")
logger.addHandler(fileHandler)
print(f"handler list: {logger._handlers}")
logger.warning("foo")
```
which produces the following to the console:
```
handler list: [<adafruit_logging.StreamHandler object at 0x10b3b6370>, <rogue_handler.RogueHandler object at 0x10b3b63d0>, <adafruit_logging.FileHandler object at 0x10b3e1700>]
0.057: WARNING - foo
Handler <rogue_handler.RogueHandler object at 0x10adfa460> produced exception: broken emit
```
and the `log.txt` file will actually contain the log record.

If you want this to behave differently, just let me know in comments and I will change it.

There do not seem to be any tests, let me know how to proceeed there. I only ran the above programs using Blinka.

[1] https://gist.github.com/vladak/15788891bdc2d4742dd106d65667b5a9