### PR TITLE
Fix typo in docstring

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -370,7 +370,7 @@ class Logger:
     def debug(self, msg: str, *args) -> None:
         """Log a debug message.
 
-        :param str fmsg: the core message string with embedded
+        :param str msg: the core message string with embedded
             formatting directives
         :param args: arguments to ``msg % args``;
             can be empty


### PR DESCRIPTION
Just a small typo.