### PR TITLE
Update adafruit_logging.py for no args

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -324,7 +324,9 @@ class Logger:
         return len(self._handlers) > 0
 
     def _log(self, level: int, msg: str, *args) -> None:
-        record = _logRecordFactory(self.name, level, msg % args, args)
+        record = _logRecordFactory(
+            self.name, level, (msg % args) if args else msg, args
+        )
         self.handle(record)
 
     def handle(self, record: LogRecord) -> None:


### PR DESCRIPTION
"fix incompatibility with python logging module and no args"

For context, I'm adapting the sensirion python-i2c-driver which uses python logging. They pass in nothing as arguments (args) sometimes to Logger.debug("blah {}".format(args)) and it blows up in adafruit logging. 
https://discord.com/channels/327254708534116352/327298996332658690/1103756170646265897

This change resolves the issue so the adafruit_logging library is more compatible with the python logging library.
Code suggested by deʃhipu: https://discord.com/channels/327254708534116352/327298996332658690/1103775516592455771