### PR TITLE
Use timestamp

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -76,7 +76,7 @@ try:
 except ImportError:
     pass
 
-__version__ = "5.2.3"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Logger.git"
 
 # pylint:disable=undefined-all-variable

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -76,7 +76,7 @@ try:
 except ImportError:
     pass
 
-__version__ = "0.0.0+auto.0"
+__version__ = "5.2.3"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Logger.git"
 
 # pylint:disable=undefined-all-variable
@@ -92,6 +92,7 @@ __all__ = [
     "StreamHandler",
     "logger_cache",
     "getLogger",
+    "useTimestamp",
     "Logger",
     "NullHandler",
     "FileHandler",
@@ -140,9 +141,26 @@ be retrieved from it:
 - ``args`` - The additional positional arguments provided
 """
 
+context = {"use_timestamp": False}
+
+
+def useTimestamp(new_value):
+    """
+    Whether to time.localtime() timestamp instead of time.monotonic() for the
+    emitted records.
+    """
+    context["use_timestamp"] = new_value
+
 
 def _logRecordFactory(name, level, msg, args):
-    return LogRecord(name, level, _level_for(level), msg, time.monotonic(), args)
+    return LogRecord(
+        name,
+        level,
+        _level_for(level),
+        msg,
+        time.monotonic() if not context["use_timestamp"] else time.localtime(),
+        args,
+    )
 
 
 class Handler:
@@ -164,6 +182,10 @@ class Handler:
 
         :param record: The record (message object) to be logged
         """
+
+        if context["use_timestamp"]:
+            # pylint: disable=line-too-long
+            return f"{record.created.tm_mon}/{record.created.tm_mday}/{record.created.tm_year - 2000} {record.created.tm_hour}:{record.created.tm_min}:{record.created.tm_sec}:{record.levelname}-{record.msg}"
 
         return f"{record.created:<0.3f}: {record.levelname} - {record.msg}"
 


### PR DESCRIPTION
adds `logging.useTimestamp(True)` which will use `time.localtime()` and a formatted timestamp in the emitted records instead of the default `time.monotonic()` 

As a future improvement it could support more configuration of formatting for the timestamp which I believe the CPYthon implementation does have.

I'm not 100% certain that the way I've implemented this functionality is the best. I had initially hoped to add it as an argument to the constructor for the handler. But it turns out that the function  `_logRecordFactory()` contains the initial creation of the record which is one spot where it needs to choose what type of value to use. Since that function is outside of the classes by itself I couldn't figure out a way to use an argument like I had hoped.