### PR TITLE
Add a log rotation function to the file handler

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -207,16 +207,19 @@ class StreamHandler(Handler):
 
 
 class FileHandler(StreamHandler):
-    """File handler for working with log files off of the microcontroller (like
-    an SD card). This handler implements a very simple log rotating system. If LogFileSizeLimit
-    is set, the handler will check to see if the log file is larger than the given limit. If the
-    log file is larger than the limit, it will rename it to the filename with _old appended. If
-    a file with _old already exsists, it will be deleted.
+    """File handler for working with log files off of the microcontroller (like an SD card).
+    This handler implements a very simple log rotating system. If LogFileSizeLimit is set, the
+    handler will check to see if the log file is larger than the given limit. If the log file is
+    larger than the limit, it is renamed and a new file is started for log entries. The old log
+    file is renamed with the OldFilePostfix variable appended to the name. If another file exsists
+    with this old file name, it will be deleted. Because there are two log files. The max size of
+    the log files is two times the limit set by LogFileSizeLimit.
 
     :param str filename: The filename of the log file
     :param str mode: Whether to write ('w') or append ('a'); default is to append
     :param int LogFileSizeLimit: The max allowable size of the log file in bytes.
-    :param str OldFilePostfix: What to append to the filename for the old log file.
+    :param str OldFilePostfix: What to append to the filename for the old log file. Defaults
+        to '_old'.
     """
 
     def __init__(

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -206,7 +206,10 @@ class StreamHandler(Handler):
 
 class FileHandler(StreamHandler):
     """File handler for working with log files off of the microcontroller (like
-    an SD card)
+    an SD card). This handler implements a very simple log rotating system. If LogFileSizeLimit
+    is set, the handler will check to see if the log file is larger than the given limit. If the
+    log file is larger than the limit, it will rename it to the filename with _old appended. If
+    a file with _old already exsists, it will be deleted.
 
     :param str filename: The filename of the log file
     :param str mode: Whether to write ('w') or append ('a'); default is to append

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -215,17 +215,22 @@ class FileHandler(StreamHandler):
     :param str filename: The filename of the log file
     :param str mode: Whether to write ('w') or append ('a'); default is to append
     :param int LogFileSizeLimit: The max allowable size of the log file in bytes.
+    :param str OldFilePostfix: What to append to the filename for the old log file.
     """
 
     def __init__(
-        self, filename: str, mode: str = "a", LogFileSizeLimit: int = None
+        self,
+        filename: str,
+        mode: str = "a",
+        LogFileSizeLimit: int = None,
+        OldFilePostfix: str = "_old",
     ) -> None:
         if mode == "r":
             raise ValueError("Can't write to a read only file")
 
         self._LogFileName = filename
         self._WriteMode = mode
-        self._OldFilePostfix = "_old"  # TODO: Make this settable by the user?
+        self._OldFilePostfix = OldFilePostfix
         self._LogFileSizeLimit = LogFileSizeLimit
 
         # Here we are assuming that if there is a period in the filename, the stuff after the period

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -210,11 +210,69 @@ class FileHandler(StreamHandler):
 
     :param str filename: The filename of the log file
     :param str mode: Whether to write ('w') or append ('a'); default is to append
+    :param int LogFileSizeLimit: The max allowable size of the log file in bytes.
     """
 
-    def __init__(self, filename: str, mode: str = "a") -> None:
+    def __init__(self, filename: str, mode: str = "a", LogFileSizeLimit: int = None) -> None:
         # pylint: disable=consider-using-with
-        super().__init__(open(filename, mode=mode))
+        if mode is 'r':
+            raise ValueError("Can't write to a read only file")
+        
+        self._LogFileName = filename
+        self._WriteMode = mode
+        self._OldFilePostfix = "_old"   #TODO: Make this settable by the user?
+        self._LogFileSizeLimit = LogFileSizeLimit
+        
+        #Here we are assuming that if there is a period in the filename, the stuff after the period
+        #is the extension of the file. It is possible that is not the case, but probably unlikely.
+        if '.' in filename:
+            [basefilename, extension] = filename.rsplit(".", 1)
+            self._OldLogFileName = basefilename + self._OldFilePostfix + "." + extension
+        else:
+            basefilename = filename
+            self._OldLogFileName = basefilename + self._OldFilePostfix
+
+        super().__init__(open(self._LogFileName, mode=self._WriteMode))
+        self.CheckLogSize()
+        
+    def CheckLogSize(self) -> None:
+        if self._LogFileSizeLimit is None:
+            #No log limit set
+            return
+        
+        #Close the log file. Probably needed if we want to delete/rename files.
+        self.close()
+        
+        #Get the size of the log file.
+        try:
+            LogFileSize = os.stat(self._LogFileName)[6]
+        except OSError as e:
+            if e.args[0] == 2:
+                #Log file does not exsist. This is okay.
+                LogFileSize = None
+            else:
+                raise e
+                
+        #Get the size of the old log file.
+        try:
+            OldLogFileSize = os.stat(self._OldLogFileName)[6]
+        except OSError as e:
+            if e.args[0] == 2:
+                #Log file does not exsist. This is okay.
+                OldLogFileSize = None
+            else:
+                raise e
+        
+        #This checks if the log file is too big. If so, it deletes the old log file and renames the
+        #log file to the old log filename.
+        if LogFileSize > self._LogFileSizeLimit:
+            print("Rotating Logs")
+            if OldLogFileSize is not None:
+                os.remove(self._OldLogFileName)
+            os.rename(self._LogFileName, self._OldLogFileName)
+        
+        #Reopen the file.
+        self.stream = open(self._LogFileName, mode=self._WriteMode)
 
     def close(self) -> None:
         """Closes the file"""
@@ -233,6 +291,7 @@ class FileHandler(StreamHandler):
 
         :param record: The record (message object) to be logged
         """
+        self.CheckLogSize()
         self.stream.write(self.format(record))
 
 

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -282,7 +282,6 @@ class RotatingFileHandler(FileHandler):
 
         # Open the file and save the handle to self.stream
         super().__init__(self._LogFileName, mode=self._WriteMode)
-        # TODO: What do we do if the log file already exsists?
 
     def doRollover(self) -> None:
         """Roll over the log files. This should not need to be called directly"""
@@ -316,8 +315,6 @@ class RotatingFileHandler(FileHandler):
 
     def GetLogSize(self) -> int:
         """Check the size of the log file."""
-        # TODO: Is this needed? I am catching the case where the file does not exsist,
-        #      but I don't know if that is a realistic case anymore.
         try:
             self.stream.flush()  # We need to call this or the file size is always zero.
             LogFileSize = os.stat(self._LogFileName)[6]

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -58,6 +58,7 @@ Attributes
 
 import time
 import sys
+import os
 from collections import namedtuple
 
 try:
@@ -278,7 +279,6 @@ class FileHandler(StreamHandler):
         # This checks if the log file is too big. If so, it deletes the old log file and renames the
         # log file to the old log filename.
         if LogFileSize > self._LogFileSizeLimit:
-            print("Rotating Logs")
             if OldLogFileSize is not None:
                 os.remove(self._OldLogFileName)
             os.rename(self._LogFileName, self._OldLogFileName)

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2019 Dave Astels for Adafruit Industries
+# SPDX-FileCopyrightText: 2024 Pat Satyshur
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
Adds a simple log rotation function to the file handler. This will keep the log files from growing without bound.

This update adds two optional variables to the `FileHandler` class.

- `LogFileSizeLimit`: the size limit of the log file in bytes.
- `OldFilePostfix`: What to append to the log filename to save the old log.

If the file size limit is set, when the `emit` function is called, the size of the log file will be compared to the limit. If the file is larger than the limit, it will be renamed and a new log file will be started. The old log file is renamed by appending `OldFilePostfix` to the file name. If there is another file with this name, it will be deleted.

If the file size limit is not set, the class acts the same as before this change.

I have tested this on an ESP32-S3 Feather running CircuitPython 9.0.3.