### PR TITLE
Add flush to the file write functions

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -179,6 +179,9 @@ class Handler:
 
         raise NotImplementedError()
 
+    def flush(self) -> None:
+        """Placeholder for flush function in subclasses."""
+
 
 #  pylint: disable=too-few-public-methods
 class StreamHandler(Handler):
@@ -414,6 +417,13 @@ class Logger:
         """
 
         return self._level
+
+    def flushHandlers(self) -> None:
+        """Flush all handlers. This will ensure that all data is immediately written to the streams.
+        This can be useful if you need to make sure the log is written before a reset.
+        """
+        for handlerName in self._handlers:
+            handlerName.flush()
 
     def addHandler(self, hdlr: Handler) -> None:
         """Adds the handler to this logger.

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -239,6 +239,7 @@ class FileHandler(StreamHandler):
         :param record: The record (message object) to be logged
         """
         self.stream.write(self.format(record))
+        self.stream.flush()
 
 
 class RotatingFileHandler(FileHandler):
@@ -338,6 +339,7 @@ class RotatingFileHandler(FileHandler):
         ):
             self.doRollover()
         self.stream.write(self.format(record))
+        self.stream.flush()
 
 
 class NullHandler(Handler):

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -206,6 +206,12 @@ class StreamHandler(Handler):
         """
         self.stream.write(self.format(record) + self.terminator)
 
+    def flush(self) -> None:
+        """flush the stream. You might need to call this if your messages
+        are not appearing in the log file.
+        """
+        self.stream.flush()
+
 
 class FileHandler(StreamHandler):
     """File handler for working with log files off of the microcontroller (like
@@ -239,7 +245,6 @@ class FileHandler(StreamHandler):
         :param record: The record (message object) to be logged
         """
         self.stream.write(self.format(record))
-        self.stream.flush()
 
 
 class RotatingFileHandler(FileHandler):
@@ -339,7 +344,6 @@ class RotatingFileHandler(FileHandler):
         ):
             self.doRollover()
         self.stream.write(self.format(record))
-        self.stream.flush()
 
 
 class NullHandler(Handler):

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -248,6 +248,7 @@ class FileHandler(StreamHandler):
         :param record: The record (message object) to be logged
         """
         self.stream.write(self.format(record))
+        self.stream.flush()
 
 
 class RotatingFileHandler(FileHandler):
@@ -347,6 +348,7 @@ class RotatingFileHandler(FileHandler):
         ):
             self.doRollover()
         self.stream.write(self.format(record))
+        self.stream.flush()
 
 
 class NullHandler(Handler):
@@ -417,13 +419,6 @@ class Logger:
         """
 
         return self._level
-
-    def flushHandlers(self) -> None:
-        """Flush all handlers. This will ensure that all data is immediately written to the streams.
-        This can be useful if you need to make sure the log is written before a reset.
-        """
-        for handlerName in self._handlers:
-            handlerName.flush()
 
     def addHandler(self, hdlr: Handler) -> None:
         """Adds the handler to this logger.


### PR DESCRIPTION
Sorry for the churn. Further testing of the logging file handlers showed that they needed a `flush()` after the `write()` command in order for the contents of the log file to be updated in a reasonable time.