### PR TITLE
Add support for multiline logs and exceptions

### DIFF
--- a/examples/logging_simpletest.py
+++ b/examples/logging_simpletest.py
@@ -25,7 +25,10 @@ assert logger.hasHandlers()
 logger.setLevel(logging.ERROR)
 logger.info("Stream Handler: Info message")
 logger.error("Stream Handler: Error message")
-
+try:
+    raise RuntimeError("Test exception handling")
+except RuntimeError as e:
+    logger.exception(e)
 # This should produce no output at all.
 
 null_logger = logging.getLogger("null")
@@ -36,3 +39,7 @@ assert null_logger.hasHandlers()
 null_logger.setLevel(logging.ERROR)
 null_logger.info("Null Handler: Info message")
 null_logger.error("Null Handler: Error message")
+try:
+    raise RuntimeError("Test exception handling")
+except RuntimeError as e:
+    null_logger.exception(e)


### PR DESCRIPTION
# SPDX-FileCopyrightText: 2021 Adafruit Industries
#
# SPDX-License-Identifier: MIT

This PR adds the exception method to the logging module. This can be
of use for detecting and recording unexpected bugs in log running 
processes.

As the exception report includes newlines, I've made newline handling 
more robust in StreamHandler.format - it splits all input lines into a 
list (which is robust to different newline formats), and then uses
terminator to separate the lines - so changing the separator now
just means changing the value of terminator. FileHandler.format is now
redundant, as we just need to specify the terminator as "\r\n"

I have tested both StreamHandler and FileHandler on a Pico W and they work
as expected
