### PR TITLE
Adding Formatter and example including timestamp

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -206,7 +206,8 @@ class Formatter:
 
         if self.defaults:
             for key, val in self.defaults.items():
-                vals[key] = val
+                if key not in vals:
+                    vals[key] = val
 
         if self.style not in ("{", "%"):
             raise ValueError(

--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -194,10 +194,10 @@ class Formatter:
         }
         if "{asctime}" in self.fmt:
             now = time.localtime()
-            vals["asctime"] = (
-                f"{now.tm_year}-{now.tm_mon:02d}-{now.tm_mday:02d} "
-                f"{now.tm_hour:02d}:{now.tm_min:02d}:{now.tm_sec:02d}"
-            )
+            # pylint: disable=line-too-long
+            vals[
+                "asctime"
+            ] = f"{now.tm_year}-{now.tm_mon:02d}-{now.tm_mday:02d} {now.tm_hour:02d}:{now.tm_min:02d}:{now.tm_sec:02d}"
 
         if self.defaults:
             for key, val in self.defaults.items():

--- a/examples/logging_formatter_example.py
+++ b/examples/logging_formatter_example.py
@@ -2,9 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 
-"""Briefly exercise the logger and null logger."""
+"""Illustrate usage of default and custom Formatters including
+one with timestamps."""
 
 import adafruit_logging as logging
+
 # To test on CPython, un-comment below and comment out above
 # import logging
 

--- a/examples/logging_formatter_example.py
+++ b/examples/logging_formatter_example.py
@@ -17,19 +17,32 @@ print_handler = logging.StreamHandler()
 logger.addHandler(print_handler)
 
 default_formatter = logging.Formatter()
+
 print_handler.setFormatter(default_formatter)
 logger.info("Default formatter example")
 
 
-timestamp_formatter = logging.Formatter(
-    fmt="{asctime} {levelname}: {message}", style="{"
-)
+timestamp_formatter = logging.Formatter(fmt="%(asctime)s %(levelname)s: %(message)s")
 print_handler.setFormatter(timestamp_formatter)
 logger.info("Timestamp formatter example")
 
 
 custom_vals_formatter = logging.Formatter(
-    fmt="{ip} {levelname}: {message}", style="{", defaults={"ip": "192.168.1.188"}
+    fmt="%(ip)s %(levelname)s: %(message)s", defaults={"ip": "192.168.1.188"}
 )
 print_handler.setFormatter(custom_vals_formatter)
 logger.info("Custom formatter example")
+
+
+bracket_timestamp_formatter = logging.Formatter(
+    fmt="{asctime} {levelname}: {message}", style="{"
+)
+print_handler.setFormatter(bracket_timestamp_formatter)
+logger.info("Timestamp formatter bracket style example")
+
+
+bracket_custom_vals_formatter = logging.Formatter(
+    fmt="{ip} {levelname}: {message}", style="{", defaults={"ip": "192.168.1.188"}
+)
+print_handler.setFormatter(bracket_custom_vals_formatter)
+logger.info("Custom formatter bracket style example")

--- a/examples/logging_formatter_example.py
+++ b/examples/logging_formatter_example.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2024 Tim Cocks
+# SPDX-License-Identifier: MIT
+
+
+"""Briefly exercise the logger and null logger."""
+
+import adafruit_logging as logging
+# To test on CPython, un-comment below and comment out above
+# import logging
+
+
+logger = logging.getLogger("example")
+logger.setLevel(logging.INFO)
+print_handler = logging.StreamHandler()
+logger.addHandler(print_handler)
+
+default_formatter = logging.Formatter()
+print_handler.setFormatter(default_formatter)
+logger.info("Default formatter example")
+
+
+timestamp_formatter = logging.Formatter(
+    fmt="{asctime} {levelname}: {message}", style="{"
+)
+print_handler.setFormatter(timestamp_formatter)
+logger.info("Timestamp formatter example")
+
+
+custom_vals_formatter = logging.Formatter(
+    fmt="{ip} {levelname}: {message}", style="{", defaults={"ip": "192.168.1.188"}
+)
+print_handler.setFormatter(custom_vals_formatter)
+logger.info("Custom formatter example")


### PR DESCRIPTION
This is intended to supersede #51.

This adds support for a subset of functionality of Formatters (https://docs.python.org/3/library/logging.html#formatter-objects) to be created and set on Handlers.

A new example is provided that illustrates the usage of a few different Formatters including one that use `{asctime}`. 

The output of this example when run in cpython with the cpython `logging` import used:
```
Default formatter example
2024-08-05 18:18:37,448 INFO: Timestamp formatter example
192.168.1.188 INFO: Custom formatter example
```

The output of this example when run in cpython with adafruit_logging import used:
```
Default formatter example

2024-08-05 18:19:19 INFO: Timestamp formatter example

192.168.1.188 INFO: Custom formatter example
```

The output of this example when run in circuitpython on a Feather S2 9.1.1
```
Default formatter example

2000-01-01 02:32:47 INFO: Timestamp formatter example

192.168.1.188 INFO: Custom formatter example
```

The Formatter init function signature matches the CPython version, but at this time not all of the functionality is implemented so some of the arguments are ignored. 

The arguments currently supported are:

- `fmt` for the custom format string
- `defaults` for a dictionary containing arbitrary extra values that can be included in the format string
- `style` this implementation only supports `'{'`


~~In CPython the default value for `sytle` is `'%'` but in this implementation have changed it to `'{'` because I didn't implement support for the percent style. The code for supporting curly brackets was minimal as it was able to leverage string.format().  I do not know if there is some simpler way to format strings with the percent format like `'%(message)s` but the only way I know of would involve regex and be somewhat complex. If anyone knows a simple way to do that I'd be willing to add it and switch the default over to `'%'` so that we can match the CPython implementation.~~

I've noticed that `adafruit_logging` seems to include extra empty lines in between the printed log messages (as depicted in sample output above). I'm not certain of the root cause of that, but I believe it's unrelated to this PR and could be fixed seperately. I tested the currently released version of this library on both CPython and Circuitpython and see the extra spaces appearing in both cases.  (edit: #62 provides a solution for the extra lines.)