### PR TITLE
remove extra newlines

### DIFF
--- a/adafruit_logging.py
+++ b/adafruit_logging.py
@@ -209,7 +209,7 @@ class StreamHandler(Handler):
         """
         text = super().format(record)
         lines = text.splitlines()
-        return self.terminator.join(lines) + self.terminator
+        return self.terminator.join(lines)
 
     def emit(self, record: LogRecord) -> None:
         """Send a message to the console.
@@ -561,7 +561,7 @@ class Logger:
             )
         else:
             lines = [str(err)] + traceback.format_exception(err)
-            lines = str(err) + "\n".join(lines)
+            lines = str(err) + "".join(lines)
             # some of the returned strings from format_exception already have newlines in them,
             # so we can't add the indent in the above line - needs to be done separately
             lines = lines.replace("\n", "\n  ")


### PR DESCRIPTION
This removes the extra newlines that are currently present in emitted messages from the StreamHandler and exceptions that get emitted.

Output of simpletest run with this PR branch:
```
41900.774: INFO - Default handler: Info message
41900.774: ERROR - Stream Handler: Error message
41900.774: ERROR - Test exception handlingTest exception handlingTraceback (most recent call last):
    File "/path/to/file/Adafruit_CircuitPython_Logging/examples/logging_simpletest.py", line 29, in <module>
      raise RuntimeError("Test exception handling")
  RuntimeError: Test exception handling
  
```

Output of simpletest run with main branch:
```
42085.612: INFO - Default handler: Info message

42085.612: ERROR - Stream Handler: Error message

42085.612: ERROR - Test exception handlingTest exception handling
  Traceback (most recent call last):
  
    File "/home/timc/repos/circuitpython/Adafruit_CircuitPython_Logging/examples/logging_simpletest.py", line 29, in <module>
      raise RuntimeError("Test exception handling")
  
  RuntimeError: Test exception handling
  

```

Output of simpletest run under cpython with `logging` instead of `adafruit_logging`:
```
Stream Handler: Error message
Test exception handling
Traceback (most recent call last):
  File "/home/timc/repos/circuitpython/Adafruit_CircuitPython_Logging/examples/logging_simpletest.py", line 29, in <module>
    raise RuntimeError("Test exception handling")
RuntimeError: Test exception handling

```